### PR TITLE
drop legend fix

### DIFF
--- a/legacy_enhancement_suite.user.js
+++ b/legacy_enhancement_suite.user.js
@@ -28,7 +28,7 @@
 // @include     http://dev.legacy-game.net/*
 // @version     0.0.47
 // @grant       none
-// @require     https://github.com/nnnick/Chart.js/raw/master/Chart.min.js
+// @require     https://raw.githubusercontent.com/nnnick/Chart.js/4aa274d5b2c82e28f7a7b2bb78db23b0429255a1/Chart.js
 // @require     http://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.1/jquery.js
 // @require     http://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.10.4/jquery-ui.js
 // @require     https://raw.githubusercontent.com/rodmk/locache/master/locache.js


### PR DESCRIPTION
Statically fixes chart.js dependency, rather than using the most recent version (oops)
